### PR TITLE
Fix resource loading for Java 9

### DIFF
--- a/libPlgVisualizer/src/plg/visualizer/util/ImageUtils.java
+++ b/libPlgVisualizer/src/plg/visualizer/util/ImageUtils.java
@@ -33,7 +33,7 @@ public class ImageUtils {
 	 */
 	public static ImageIcon loadImage(String imageFile, int width, int height) {
 		try {
-			return new ImageIcon(ImageIO.read(System.class.getResource(imageFile)).getScaledInstance(width, height, BufferedImage.SCALE_FAST));
+			return new ImageIcon(ImageIO.read(ClassLoader.getSystemResource(imageFile)).getScaledInstance(width, height, BufferedImage.SCALE_FAST));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -50,8 +50,7 @@ public class ImageUtils {
 	 */
 	public static ImageIcon loadImage(String imageFile) {
 		try {
-//			return new ImageIcon(ImageIO.read(new File(imageFile)));
-			return new ImageIcon(ImageIO.read(System.class.getResource(imageFile)));
+			return new ImageIcon(ImageIO.read(ClassLoader.getSystemResource(imageFile)));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/plg/src/plg/gui/util/ImageUtils.java
+++ b/plg/src/plg/gui/util/ImageUtils.java
@@ -33,7 +33,7 @@ public class ImageUtils {
 	 */
 	public static ImageIcon loadImage(String imageFile, int width, int height) {
 		try {
-			return new ImageIcon(ImageIO.read(System.class.getResource(imageFile)).getScaledInstance(width, height, BufferedImage.SCALE_FAST));
+			return new ImageIcon(ImageIO.read(ClassLoader.getSystemResource(imageFile)).getScaledInstance(width, height, BufferedImage.SCALE_FAST));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -50,8 +50,7 @@ public class ImageUtils {
 	 */
 	public static ImageIcon loadImage(String imageFile) {
 		try {
-//			return new ImageIcon(ImageIO.read(new File(imageFile)));
-			return new ImageIcon(ImageIO.read(System.class.getResource(imageFile)));
+			return new ImageIcon(ImageIO.read(ClassLoader.getSystemResource(imageFile)));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/plg/src/plg/gui/util/collections/ImagesCollection.java
+++ b/plg/src/plg/gui/util/collections/ImagesCollection.java
@@ -12,23 +12,23 @@ import plg.gui.util.ImageUtils;
 public class ImagesCollection {
 
 	// General PLG icons
-	public static final ImageIcon PLG_ICON = ImageUtils.loadImage("/plg/resources/icons/plg.png");
-	public static final ImageIcon PLG_ICON_SCALED = ImageUtils.loadImage("/plg/resources/icons/application-icon.png", 32, 32);
-	public static final ImageIcon ERROR_ICON = ImageUtils.loadImage("/plg/resources/icons/error.png");
-	public static final ImageIcon HELP_ICON = ImageUtils.loadImage("/plg/resources/icons/famfamfam/book_open.png");
-	public static final ImageIcon UPDATES_ICON = ImageUtils.loadImage("/plg/resources/icons/updates.png");
+	public static final ImageIcon PLG_ICON = ImageUtils.loadImage("plg/resources/icons/plg.png");
+	public static final ImageIcon PLG_ICON_SCALED = ImageUtils.loadImage("plg/resources/icons/application-icon.png", 32, 32);
+	public static final ImageIcon ERROR_ICON = ImageUtils.loadImage("plg/resources/icons/error.png");
+	public static final ImageIcon HELP_ICON = ImageUtils.loadImage("plg/resources/icons/famfamfam/book_open.png");
+	public static final ImageIcon UPDATES_ICON = ImageUtils.loadImage("plg/resources/icons/updates.png");
 	
 	// Toolbar icons
-	public static final ImageIcon ICON_NEW = ImageUtils.loadImage("/plg/resources/icons/famfamfam/page_add.png");
-	public static final ImageIcon ICON_OPEN = ImageUtils.loadImage("/plg/resources/icons/famfamfam/folder_page.png");
-	public static final ImageIcon ICON_DELETE = ImageUtils.loadImage("/plg/resources/icons/famfamfam/page_delete.png");
-	public static final ImageIcon ICON_EVOLVE = ImageUtils.loadImage("/plg/resources/icons/famfamfam/page_refresh.png");
-	public static final ImageIcon ICON_SAVE = ImageUtils.loadImage("/plg/resources/icons/famfamfam/disk.png");
-	public static final ImageIcon ICON_LOG = ImageUtils.loadImage("/plg/resources/icons/famfamfam/table_go.png");
-	public static final ImageIcon ICON_STREAM = ImageUtils.loadImage("/plg/resources/icons/famfamfam/transmit_go.png");
-	public static final ImageIcon ICON_CONSOLE = ImageUtils.loadImage("/plg/resources/icons/famfamfam/application_xp_terminal.png");
+	public static final ImageIcon ICON_NEW = ImageUtils.loadImage("plg/resources/icons/famfamfam/page_add.png");
+	public static final ImageIcon ICON_OPEN = ImageUtils.loadImage("plg/resources/icons/famfamfam/folder_page.png");
+	public static final ImageIcon ICON_DELETE = ImageUtils.loadImage("plg/resources/icons/famfamfam/page_delete.png");
+	public static final ImageIcon ICON_EVOLVE = ImageUtils.loadImage("plg/resources/icons/famfamfam/page_refresh.png");
+	public static final ImageIcon ICON_SAVE = ImageUtils.loadImage("plg/resources/icons/famfamfam/disk.png");
+	public static final ImageIcon ICON_LOG = ImageUtils.loadImage("plg/resources/icons/famfamfam/table_go.png");
+	public static final ImageIcon ICON_STREAM = ImageUtils.loadImage("plg/resources/icons/famfamfam/transmit_go.png");
+	public static final ImageIcon ICON_CONSOLE = ImageUtils.loadImage("plg/resources/icons/famfamfam/application_xp_terminal.png");
 	
 	// Other icons
-	public static final ImageIcon ICON_PLAY = ImageUtils.loadImage("/plg/resources/icons/famfamfam/control_play_blue.png");
-	public static final ImageIcon ICON_STOP = ImageUtils.loadImage("/plg/resources/icons/famfamfam/control_stop_blue.png");
+	public static final ImageIcon ICON_PLAY = ImageUtils.loadImage("plg/resources/icons/famfamfam/control_play_blue.png");
+	public static final ImageIcon ICON_STOP = ImageUtils.loadImage("plg/resources/icons/famfamfam/control_stop_blue.png");
 }

--- a/plg/src/plg/gui/util/collections/ScriptsCollection.java
+++ b/plg/src/plg/gui/util/collections/ScriptsCollection.java
@@ -11,9 +11,9 @@ import java.util.Scanner;
 public class ScriptsCollection {
 
 	// various scripts
-	public static final String TIME_SCRIPT = getFile("/plg/resources/scripts/taskTime.py");
-	public static final String STRING_DATA_OBJECT = getFile("/plg/resources/scripts/dataObjectString.py");
-	public static final String INTEGER_DATA_OBJECT = getFile("/plg/resources/scripts/dataObjectInteger.py");
+	public static final String TIME_SCRIPT = getFile("plg/resources/scripts/taskTime.py");
+	public static final String STRING_DATA_OBJECT = getFile("plg/resources/scripts/dataObjectString.py");
+	public static final String INTEGER_DATA_OBJECT = getFile("plg/resources/scripts/dataObjectInteger.py");
 	
 	/**
 	 * This method returns a string representation of the provided resource. The
@@ -25,7 +25,7 @@ public class ScriptsCollection {
 	 */
 	public static String getFile(String resourceName) {
 		StringBuilder result = new StringBuilder("");
-		InputStream is = System.class.getResourceAsStream(resourceName);
+		InputStream is = ClassLoader.getSystemResourceAsStream(resourceName);
 		try (Scanner scanner = new Scanner(is)) {
 			while (scanner.hasNextLine()) {
 				String line = scanner.nextLine();


### PR DESCRIPTION
Hi, 

thank you for creating this neat program :)

In Java 9 the resource loading behavior was updated see http://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html. This prevented the program to start because the icons could not be found.

> The Class::getResource and Class::getResourceAsStream methods have been updated in Java SE 9 so that invoking them on a Class in a named module will only locate the resource in the module. This may impact code that invokes these methods on platform classes on the assumption that the class path will be searched. Code that needs to search the class path for a resource should be changed to use ClassLoader::getSystemResource or ClassLoader::getSystemResourceAsStream.

Kind regards,
Markus